### PR TITLE
Change the SunIcon stoke to dark

### DIFF
--- a/packages/Linkees/src/components/components/Icons/SunIcon.tsx
+++ b/packages/Linkees/src/components/components/Icons/SunIcon.tsx
@@ -9,7 +9,7 @@ export default function SunIcon(props: IIcon): JSX.Element {
       height="24"
       viewBox="0 0 24 24"
       fill="none"
-      stroke="currentColor"
+      stroke="#333"
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"


### PR DESCRIPTION
The sun Icon on light mode was not very visible with the current stroke, thus I changing it to darker stroke made it more visible.