### PR TITLE
Change SunIcon to black color

### DIFF
--- a/packages/Linkees/src/components/components/Header.tsx
+++ b/packages/Linkees/src/components/components/Header.tsx
@@ -30,7 +30,7 @@ function Header({ avatar, name }: { avatar?: string; name: string }): JSX.Elemen
         </h2>
       </div>
       <button className="switch-theme-button" onClick={handleSwitchTheme}>
-        {isDark ? <SunIcon color="white" /> : <MoonIcon />}
+        {isDark ? <SunIcon color="black" /> : <MoonIcon />}
       </button>
     </div>
   );


### PR DESCRIPTION
The sun Icon is not properly visible in the dark mode because of the light icon color and light background.
So changed it to black which makes it more visible.