### PR TITLE
Adding Padding after Footer.

### DIFF
--- a/packages/Linkees/src/components/components/Footer.tsx
+++ b/packages/Linkees/src/components/components/Footer.tsx
@@ -5,7 +5,7 @@ import '../../css/components.css';
 
 function Footer(): JSX.Element {
   return (
-    <div className="Footer container pb-10">
+    <div className="Footer container">
       <p>
         Made with <span className="heart">❤️</span> by <a href={'https://twitter.com/heysagnik'}>Sagnik Sahoo</a>
       </p>

--- a/packages/Linkees/src/components/components/Footer.tsx
+++ b/packages/Linkees/src/components/components/Footer.tsx
@@ -5,7 +5,7 @@ import '../../css/components.css';
 
 function Footer(): JSX.Element {
   return (
-    <div className="Footer container">
+    <div className="Footer container pb-10">
       <p>
         Made with <span className="heart">❤️</span> by <a href={'https://twitter.com/heysagnik'}>Sagnik Sahoo</a>
       </p>

--- a/packages/Linkees/src/css/components.css
+++ b/packages/Linkees/src/css/components.css
@@ -99,6 +99,7 @@ p {
 .Footer {
   font-size: small;
   text-align: center;
+  padding-bottom: 20px;
 }
 
 .heart {


### PR DESCRIPTION
In Chromebook, and laptops the footer doesn't have space at the bottom, making it stick to the bottom of the website. which makes it look wierd.
![image](https://github.com/heysagnik/Linkees/assets/100826194/ae43347b-9d0c-4c60-9c49-e7b764ae256c)
so i thought of adding a little place

also i didnt check if u installed tailwind or no, in a hurry. but u get the idea..