### PR TITLE
move document access to useEffect

### DIFF
--- a/packages/Linkees/src/components/components/Header.tsx
+++ b/packages/Linkees/src/components/components/Header.tsx
@@ -7,8 +7,12 @@ import '../../css/components.css';
 import { ThemeType } from '../../ts/types';
 
 function Header({ avatar, name }: { avatar?: string; name: string }): JSX.Element {
-  const dataTheme = document.body.getAttribute('data-theme');
-  const [theme, setTheme] = React.useState<ThemeType>((): ThemeType => (dataTheme === 'light' ? 'light' : 'dark'));
+  const [theme, setTheme] = React.useState<ThemeType>("light");
+
+  React.useEffect(() => {
+    const dataTheme = document.body.getAttribute('data-theme');
+    setTheme(dataTheme === 'light' ? 'light' : 'dark');
+  }, []);
 
   React.useEffect(() => {
     document.body.setAttribute('data-theme', theme);


### PR DESCRIPTION
accessing `document` in the component can cause issues when using SSR. It's safer to wrap this in a `useEffect` to ensure it's run client-side 